### PR TITLE
Handle orphaned recurrence overrides

### DIFF
--- a/src/calsync_claude/sync_engine.py
+++ b/src/calsync_claude/sync_engine.py
@@ -1251,8 +1251,13 @@ class SyncEngine:
                 else:
                     # This might be a false positive - treat as normal standalone event
                     self.logger.debug(f"✅ Event {override_event.id} reclassified as standalone (not a recurrence override)")
-                
-                # In both cases, treat as standalone event to ensure it gets synced
+
+                # In both cases, strip recurrence metadata and treat as standalone event to ensure it gets synced
+                # Without this cleanup Google API will reject creation with "Invalid resource id value" when
+                # recurringEventId references a non-existent master event.
+                override_event.recurrence_overrides = []
+                override_event.recurring_event_id = None
+
                 grouped[override_event.id] = {
                     'master': override_event,
                     'overrides': []

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -1,0 +1,37 @@
+import pytz
+from datetime import datetime
+
+from calsync_claude.config import Settings
+from calsync_claude.sync_engine import SyncEngine
+from calsync_claude.models import CalendarEvent, EventSource
+
+
+def make_settings(tmp_path):
+    return Settings(
+        google_client_id='x'*20,
+        google_client_secret='y'*20,
+        icloud_username='user@example.com',
+        icloud_password='app-password-123',
+        database_url=f'sqlite:///{tmp_path}/test.db'
+    )
+
+
+def test_orphaned_override_clears_recurrence(tmp_path):
+    settings = make_settings(tmp_path)
+    engine = SyncEngine(settings)
+
+    override = CalendarEvent(
+        id='override1',
+        uid='UID-1',
+        source=EventSource.ICLOUD,
+        summary='Orphaned Override',
+        start=datetime(2023,1,1,tzinfo=pytz.UTC),
+        end=datetime(2023,1,1,1,tzinfo=pytz.UTC),
+        recurrence_overrides=[{'type':'recurrence-id','is_override':True,'master_event_id':'missing'}],
+        recurring_event_id='missing'
+    )
+
+    grouped = engine._group_recurrence_events({'override1': override})
+    standalone = grouped['override1']['master']
+    assert standalone.recurrence_overrides == []
+    assert standalone.recurring_event_id is None


### PR DESCRIPTION
## Summary
- Clear recurrence metadata on orphaned overrides to avoid invalid Google IDs
- Add regression test ensuring orphaned overrides sync as standalone events

## Testing
- `pytest -q -o addopts=""` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic pydantic-settings` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_689a104abbc08330a7853c7a6079ec6c